### PR TITLE
Add email sending utility with unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pytest --cov=customer_care
 ```
 
 The tests cover every module to ensure 100% coverage.
-=======
+
 This repository contains a simple demonstration of an automated customer complaint management workflow. The workflow is composed of modular agents as described in `agents.md`.
 
 ## Running the Example

--- a/customer_care/__init__.py
+++ b/customer_care/__init__.py
@@ -1,6 +1,4 @@
 
-__all__ = []
-=======
 """Customer Care agents package."""
 
 from .email_receiver import EmailReceiver

--- a/customer_care/email_receiver.py
+++ b/customer_care/email_receiver.py
@@ -1,6 +1,4 @@
 
-"""Placeholder email receiver."""
-=======
 """Email Receiver Agent.
 
 This agent would normally connect to Office 365 to fetch new complaint emails.
@@ -8,28 +6,19 @@ In this simplified example, it returns mock email data.
 """
 from __future__ import annotations
 
-
 from typing import Iterable
 
 
 class EmailReceiver:
-
     def __init__(self, inbox_id: str):
         self.inbox_id = inbox_id
 
     def receive(self) -> Iterable[str]:
         """Simulate receiving raw email texts."""
-        # Placeholder implementation
         return []
-=======
-    def fetch_emails(self) -> Iterable[dict]:
-        """Fetch new complaint emails.
 
-        Returns an iterable of dictionaries with 'from', 'subject', and 'body'.
-        """
-        # In a real system, this method would connect to the Office 365 inbox
-        # using Microsoft Graph API or IMAP and return raw email content.
-        # Here we return sample messages for demonstration purposes.
+    def fetch_emails(self) -> Iterable[dict]:
+        """Fetch new complaint emails."""
         return [
             {
                 "from": "customer@example.com",
@@ -37,4 +26,3 @@ class EmailReceiver:
                 "body": "OrderReference: 123\nI received a damaged product.",
             }
         ]
-==

--- a/customer_care/forwarding_agent.py
+++ b/customer_care/forwarding_agent.py
@@ -1,8 +1,13 @@
 
 """Forward tickets to internal recipients."""
 
+from __future__ import annotations
+
+from typing import Iterable
+
 from .config import Config
 from .data_extraction import TicketData
+from .data_models import ComplaintTicket
 
 
 FORWARD_TEMPLATE = (
@@ -21,13 +26,6 @@ def format_forward(ticket: TicketData, case_number: int) -> str:
 
 def recipients(config: Config) -> list:
     return config.recipients
-=======
-"""Forwarding Agent."""
-from __future__ import annotations
-
-from typing import Iterable
-
-from .data_models import ComplaintTicket
 
 
 class ForwardingAgent:
@@ -36,10 +34,8 @@ class ForwardingAgent:
 
     def forward(self, ticket: ComplaintTicket) -> None:
         """Forward ticket details to configured recipients."""
-        # In a real system this would send an email or push notification.
         for recipient in self.recipients:
             print(
-                f"Forwarding ticket {ticket.case_number} to {recipient}:"
-                f" {ticket.complaint_description}"
+                f"Forwarding ticket {ticket.case_number} to {recipient}: {ticket.complaint_description}"
             )
 

--- a/customer_care/response_agent.py
+++ b/customer_care/response_agent.py
@@ -1,6 +1,12 @@
 
-"""Generate customer responses."""
+"""Generate and send customer responses."""
 
+from __future__ import annotations
+
+import smtplib
+from typing import Any
+
+from .config import Config
 from .data_extraction import TicketData
 
 
@@ -16,27 +22,33 @@ REQ_TEMPLATE = (
 
 
 def acknowledgement(ticket: TicketData, case_number: int) -> str:
+    """Return acknowledgement email body for a ticket."""
     return ACK_TEMPLATE.format(email=ticket.customer_email, case=case_number)
 
 
 def request_more_info(email: str) -> str:
+    """Return body requesting more information from the customer."""
     return REQ_TEMPLATE.format(email=email)
-=======
-"""Response Agent."""
-from __future__ import annotations
 
-from typing import Any
+
+def send_email(recipient: str, body: str, config: Config) -> None:
+    """Send an email using ``smtplib`` based on the provided configuration."""
+    message = f"From: {config.email_user}\nTo: {recipient}\n\n{body}"
+    with smtplib.SMTP("localhost") as smtp:
+        smtp.login(config.email_user, config.email_password)
+        smtp.sendmail(config.email_user, [recipient], message)
 
 
 class ResponseAgent:
+    def __init__(self, config: Config | None = None) -> None:
+        self.config = config or Config()
+
     def request_more_info(self, customer_email: str) -> Any:
         """Send an email requesting missing information."""
-        # Placeholder for sending email
-        print(f"Requesting more info from {customer_email}")
+        body = REQ_TEMPLATE.format(email=customer_email)
+        send_email(customer_email, body, self.config)
 
     def send_acknowledgement(self, customer_email: str, case_number: str) -> Any:
         """Send acknowledgement email with case number."""
-        # Placeholder for sending email
-        print(
-            f"Acknowledgement sent to {customer_email} for case {case_number}"
-        )
+        body = ACK_TEMPLATE.format(email=customer_email, case=case_number)
+        send_email(customer_email, body, self.config)

--- a/tests/test_response_agent.py
+++ b/tests/test_response_agent.py
@@ -1,5 +1,12 @@
-from customer_care.response_agent import acknowledgement, request_more_info
+from unittest import mock
+
+from customer_care.response_agent import (
+    acknowledgement,
+    request_more_info,
+    ResponseAgent,
+)
 from customer_care.data_extraction import TicketData
+from customer_care.config import Config
 
 
 def test_acknowledgement():
@@ -12,3 +19,23 @@ def test_acknowledgement():
 def test_request_more_info():
     msg = request_more_info("a@b.c")
     assert "more information" in msg
+
+
+def test_response_agent_emails():
+    agent = ResponseAgent(Config())
+    with mock.patch("customer_care.response_agent.send_email") as send_mock:
+        agent.send_acknowledgement("c@example.com", "5")
+        send_mock.assert_called_once()
+        args = send_mock.call_args[0]
+        assert args[0] == "c@example.com"
+        assert "case number is 5" in args[1]
+
+
+def test_request_email_via_agent():
+    agent = ResponseAgent(Config())
+    with mock.patch("customer_care.response_agent.send_email") as send_mock:
+        agent.request_more_info("d@example.com")
+        send_mock.assert_called_once()
+        args = send_mock.call_args[0]
+        assert args[0] == "d@example.com"
+        assert "more information" in args[1]


### PR DESCRIPTION
## Summary
- add `send_email` helper using `smtplib`
- update `ResponseAgent` to actually send mails
- clean up modules left with merge markers
- test ResponseAgent interactions with `send_email`

## Testing
- `PYTHONPATH=$PWD pytest --cov=customer_care -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d09ef9248332a8de88b15a84f95d